### PR TITLE
Fix golinkshort click count bug

### DIFF
--- a/server/internal/handlers/redirect.go
+++ b/server/internal/handlers/redirect.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"hypergo/internal/storage"
 )
@@ -25,8 +26,22 @@ func (r *RedirectHandler) Handler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	
-	shortcode := req.URL.Path[1:] // Remove leading slash
-	if shortcode == "api" || shortcode == "" {
+	// Normalize path to extract shortcode
+	path := strings.TrimPrefix(req.URL.Path, "/") // remove leading slash
+
+	// Ignore API and static routes
+	if path == "" || path == "api" || strings.HasPrefix(path, "api/") || strings.HasPrefix(path, "static/") {
+		http.NotFound(w, req)
+		return
+	}
+
+	// Support optional "/go/" prefix so both "/shortcode" and "/go/shortcode" work
+	if strings.HasPrefix(path, "go/") {
+		path = strings.TrimPrefix(path, "go/")
+	}
+
+	shortcode := strings.Trim(path, "/")
+	if shortcode == "" {
 		http.NotFound(w, req)
 		return
 	}


### PR DESCRIPTION
Ensures click counts increment for both `/shortcode` and `/go/:shortcode` URLs.

Previously, only direct shortcode paths (e.g., `/shortcode`) correctly incremented click counts, while paths prefixed with `/go/` (e.g., `/go/shortcode`) did not. This change normalizes the request path to correctly extract the shortcode, ensuring consistent click tracking for both URL formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-853419bc-a4c4-4fde-a52f-a06bd2168bb9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-853419bc-a4c4-4fde-a52f-a06bd2168bb9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

